### PR TITLE
Fetching medflex from github

### DIFF
--- a/mediation/Dockerfile
+++ b/mediation/Dockerfile
@@ -11,6 +11,8 @@ ENV DSMEDIATION_VERSION 0.0.3
 ENV ROCK_LIB /var/lib/rock/R/library
 
 # Install new R packages
+# medflex
+RUN Rscript -e "remotes::install_github('jmpsteen/medflex', dependencies = TRUE, upgrade = FALSE, lib = '$ROCK_LIB')"
 # dsMediation
 RUN Rscript -e "remotes::install_github('datashield/dsMediation', ref = '$DSMEDIATION_VERSION', repos = c('https://cloud.r-project.org', 'https://cran.datashield.org'), upgrade = FALSE, lib = '$ROCK_LIB')"
 


### PR DESCRIPTION
Seems medflex was removed from the cran repository and is needed for dsMediation to build.

Ref. [https://cran.r-project.org/web/packages/medflex/index.html](https://cran.r-project.org/web/packages/medflex/index.html)