### PR TITLE
Make ROCK_LIB owned earlier

### DIFF
--- a/dolomite-xenon/Dockerfile
+++ b/dolomite-xenon/Dockerfile
@@ -14,6 +14,8 @@ ENV DSURVIVAL_VERSION v2.1.3
 
 
 ENV ROCK_LIB /var/lib/rock/R/library
+RUN chown rock $ROCK_LIB
+RUN chmod +t $ROCK_LIB
 
 # Install new R packages
 # dsMediation
@@ -28,5 +30,3 @@ RUN Rscript -e "BiocManager::install(c('bumphunter', 'missMethyl', 'rexposome'),
 # dsOmics
 RUN Rscript -e "BiocManager::install(c('Biobase', 'SNPRelate', 'GENESIS', 'GWASTools', 'GenomicRanges', 'SummarizedExperiment', 'DESeq2', 'edgeR', 'MEAL'), update = FALSE, ask = FALSE, lib = '$ROCK_LIB')" \
  && Rscript -e "remotes::install_github('isglobal-brge/dsOmics', ref = '$DSOMICS_VERSION', upgrade = FALSE, lib = '$ROCK_LIB')"
-
-RUN chown -R rock $ROCK_LIB


### PR DESCRIPTION
I assume this will skip the last layer reducing 2GB ... not sure so let's see

I wonder what would happen when we make the $ROCK_LIB owned early and make it sticky which should mimic this latter last step

```docker
RUN /bin/sh -c chown -R rock $ROCK_LIB # buildkit
```